### PR TITLE
Add high risk AI aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,14 +106,14 @@ Dev-Ai-Agent 以 `debian:bookworm-slim` 為基礎，建置一個非 root 的 `ai
 
 ## AI 工具速覽
 
-| 工具               | 指令                                     | 補充                                                                                                                           |
-| ------------------ | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Claude Code        | `claude`, `claude chat`, `claude edit`   | `setup-claude.sh` 會加入 `cc`, `cchelp`, `cskip` 等 alias；`cskip` 會啟用 `--dangerously-skip-permissions`，僅適用於可信環境。 |
-| Gemini CLI         | `gemini`, `gemini chat`                  | `setup-gemini.sh` 可建立 `gchat` 等別名，並載入繁中說明的 instructions。                                                       |
-| Codex CLI          | `codex`, `codex --profile <name>`        | `config.toml` 已定義 OpenAI、Ollama、vLLM 等 profiles。                                                                        |
-| Grok CLI           | `grok`                                   | 由 Dockerfile 全域安裝，可直接對話。                                                                                           |
-| GitHub Copilot CLI | `copilot chat`, `copilot suggest`        | 建議預先設定 `GH_TOKEN` 以利無頭環境登入。                                                                                     |
-| Spec Workflow      | `claude-code-spec-workflow`, `spec-dash` | 透過 `setup-spec-workflow.sh` 追加 `spec-get-steering` 等 alias，搭配 `npx ... claude-spec-dashboard`。                        |
+| 工具               | 指令                                     | 補充 |
+| ------------------ | ---------------------------------------- | ----- |
+| Claude Code        | `claude`, `claude chat`, `claude edit`   | 手動執行 `~/.claude/setup-claude.sh` 後會加入 `cc`, `cchelp`, `cskip`, `ccgod` 等 alias；`cskip`/`ccgod` 會跳過安全檢查，僅在可完全信任的倉庫使用。 |
+| Gemini CLI         | `gemini`, `gemini chat`                  | 手動執行 `~/.gemini/setup-gemini.sh` 後會建立 `gchat`, `ggod` 等別名；`ggod` 會以 `--yolo` 模式繞過確認，請特別留意執行風險。 |
+| Codex CLI          | `codex`, `codex --profile <name>`        | `config.toml` 已定義 OpenAI、Ollama、vLLM 等 profiles；執行 `~/.codex/setup-codex.sh` 會加入 `cx`, `cxgod` 等 alias，其中 `cxgod` 會略過 sandbox 與審核程序。 |
+| Grok CLI           | `grok`                                   | 由 Dockerfile 全域安裝，可直接對話。 |
+| GitHub Copilot CLI | `copilot chat`, `copilot suggest`        | 建議預先設定 `GH_TOKEN` 以利無頭環境登入。 |
+| Spec Workflow      | `claude-code-spec-workflow`, `spec-dash` | 透過 `setup-spec-workflow.sh` 追加 `spec-get-steering` 等 alias，搭配 `npx ... claude-spec-dashboard`。 |
 
 ## Git 與資料持久化
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -63,6 +63,9 @@ docker exec -it aiagent bash
 ### Claude Code CLI
 
 ```bash
+# 建議先執行一次設定腳本以安裝 alias
+bash ~/.claude/setup-claude.sh
+
 # 初始化 Claude Code
 claude
 
@@ -74,26 +77,45 @@ claude "請幫我分析這個程式碼"
 
 # 跳過權限提示 (危險) — 需信任環境才使用
 cskip  # 等同於：claude --dangerously-skip-permissions
+# 完全跳過權限與安全防護 (極度危險)
+ccgod  # 等同於：claude --dangerously-skip-permissions
 ```
 
-注意：`cskip` 會直接跳過 Claude Code 的權限請求流程，可能導致未經確認的檔案/命令操作，請僅在可信任的倉庫與可控環境使用。
+注意：`cskip` 與 `ccgod` 會直接跳過 Claude Code 的權限請求流程，可能導致未經確認的檔案/命令操作，請僅在可信任的倉庫與可控環境使用。
 
 ### Codex CLI (OpenAI)
 
 ```bash
+# 建議先執行一次設定腳本以安裝 alias
+bash ~/.codex/setup-codex.sh
+
 # 登入
 codex login
 
 # 使用 codex-cli
 codex "write a python function to sort a list"
+
+# 跳過 sandbox/審核 (極度危險)
+cxgod "deploy my app"  # 等同於：codex --dangerously-bypass-approvals-and-sandbox "deploy my app"
 ```
+
+注意：`cxgod` 會跳過 Codex CLI 的 sandbox 與審核步驟，請僅在完全受控的環境執行。
 
 ### Gemini CLI
 
 ```bash
+# 建議先執行一次設定腳本以安裝 alias
+bash ~/.gemini/setup-gemini.sh
+
 # 使用 gemini-cli
 gemini "explain this code snippet"
+
+# 使用快速別名（含高風險指令）
+gchat "請用繁中說明這段程式"  # 一般聊天快捷指令
+ggod "直接改寫整個專案"       # 等同於：gemini --yolo "直接改寫整個專案"
 ```
+
+注意：`ggod` 會以 `--yolo` 模式執行 Gemini CLI，跳過額外提示或確認。請僅在完全信任的專案環境內使用。
 
 ## 檔案管理
 

--- a/config/claude/setup-claude.sh
+++ b/config/claude/setup-claude.sh
@@ -14,6 +14,8 @@ alias cchat='claude chat'
 alias cedit='claude edit'
 alias cconfig='claude config'
 alias cinit='claude init'
+# ⚠️ Danger: runs Claude with all permission prompts skipped.
+alias ccgod='claude --dangerously-skip-permissions'
 
 # Skip permission prompts (use with caution)
 alias cskip='claude --dangerously-skip-permissions'

--- a/config/codex/setup-codex.sh
+++ b/config/codex/setup-codex.sh
@@ -15,6 +15,7 @@ ALIASES=(
     "alias cxhelp='codex --help'"
     "alias cxconfig='codex --config ~/.codex/config.toml'"
     "alias cxfile='codex --file'"
+    "alias cxgod='codex --dangerously-bypass-approvals-and-sandbox'"
 )
 
 for alias_cmd in "${ALIASES[@]}"; do

--- a/config/gemini/setup-gemini.sh
+++ b/config/gemini/setup-gemini.sh
@@ -6,6 +6,7 @@ echo "🛠 初始化 Gemini CLI 全域設定..."
 # 建立 alias 到 .bashrc
 if ! grep -q "alias gchat" ~/.bashrc; then
     echo "alias gchat='gemini chat --instructions ~/.gemini/instructions.txt'" >> ~/.bashrc
+    echo "alias ggod='gemini --yolo'" >> ~/.bashrc
     echo "✅ 已添加 gchat alias 到 .bashrc"
 else
     echo "ℹ️  gchat alias 已存在於 .bashrc"


### PR DESCRIPTION
## Summary
- add god-mode aliases for Claude, Gemini, and Codex setup scripts with explicit warnings
- document the new aliases and their risks in the AI tool overview and CLI usage guide

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df07ef93cc832da6bb53fbb0b10393