### PR TITLE
Add script to enable Copilot godmode alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Dev-Ai-Agent 以 `debian:bookworm-slim` 為基礎，建置一個非 root 的 `ai
    bash ~/.gemini/setup-gemini.sh
    bash ~/.codex/setup-codex.sh
    bash ~/.claude/setup-spec-workflow.sh   # 啟用 Spec Workflow 快捷指令
+   bash config/scripts/setup-copilot-godmode.sh  # 啟用 ctgod（Copilot --allow-all-tools，請確認環境安全）
    ```
 
 更多指令（重新建置、關閉容器等）請參考 [USAGE.md](USAGE.md)。

--- a/USAGE.md
+++ b/USAGE.md
@@ -95,6 +95,15 @@ codex "write a python function to sort a list"
 gemini "explain this code snippet"
 ```
 
+### GitHub Copilot CLI
+
+```bash
+# （可選）啟用 ctgod alias，讓 Copilot 以 --allow-all-tools 執行
+bash config/scripts/setup-copilot-godmode.sh
+```
+
+> ⚠️ 警告：`ctgod` 會以 `copilot --allow-all-tools` 形式執行，跳過工具權限確認步驟，可能在未提示的情況下呼叫外部指令或修改檔案。請僅在完全信任的專案與執行環境中啟用，並確保瞭解其中風險。
+
 ## 檔案管理
 
 ### 工作目錄

--- a/config/scripts/setup-copilot-godmode.sh
+++ b/config/scripts/setup-copilot-godmode.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_FILE="${HOME}/.bashrc"
+ALIAS_LINE="alias ctgod='copilot --allow-all-tools'"
+
+cat <<'WARN'
+⚠️  WARNING: The ctgod alias runs GitHub Copilot CLI with --allow-all-tools, bypassing tool approval prompts. Enable only in fully trusted environments and repositories.
+WARN
+
+if [ ! -f "$TARGET_FILE" ]; then
+  touch "$TARGET_FILE"
+fi
+
+if grep -Fxq "$ALIAS_LINE" "$TARGET_FILE"; then
+  echo "Alias already present in $TARGET_FILE; no changes made."
+else
+  {
+    echo
+    echo "$ALIAS_LINE"
+  } >> "$TARGET_FILE"
+  echo "Alias appended to $TARGET_FILE. Restart your shell to use ctgod."
+fi


### PR DESCRIPTION
## Summary
- add a helper script that appends the ctgod alias for Copilot with --allow-all-tools and prints a warning
- document the optional script in the README alias list and add usage guidance with risk warnings in USAGE.md

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df07f31aa4832da88a9634976bcddd